### PR TITLE
Add Stage-native caller-loop task ownership for 0.3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,9 @@ authorization, or compensation policy for those effects.
 On the Stage-owned carrier, tasks created inside Stage work are retained by the
 carrier task factory. On a caller-owned loop, Stage deliberately does not
 replace the loop's task factory: settlement covers work created through
-`Stage.go()` and tasks explicitly attached with `Stage.adopt()`. An unrelated
-raw `asyncio.create_task()` remains owned by the caller.
+`Stage.go()`, native tasks created through `Stage.create_task()`, and existing
+tasks explicitly attached with `Stage.adopt()`. An unrelated raw
+`asyncio.create_task()` remains owned by the caller.
 
 ### Callback observers
 
@@ -228,7 +229,37 @@ When a settlement timeout expires, Stage raises `TimeoutError` with unresolved
 origins. The scope remains sealed, and `close()` may be called again after the
 outstanding work settles.
 
-### Adopt caller-loop tasks
+### Create or adopt caller-loop tasks
+
+`create_task()` creates a native `asyncio.Task` on the current running caller
+loop and makes Stage its lifecycle owner in one operation:
+
+```python
+import asyncio
+
+from agently_stage import Stage
+
+
+async def main() -> None:
+    async def hook() -> str:
+        await asyncio.sleep(0)
+        return "ready"
+
+    stage = Stage()
+    task = stage.create_task(hook(), origin="event:ready-hook")
+
+    assert isinstance(task, asyncio.Task)
+    assert await task == "ready"
+    await stage.async_close(timeout=1)
+
+
+asyncio.run(main())
+```
+
+This surface is for frameworks that already run on an asyncio loop and require
+native task identity for `gather`, cancellation, and current-task checks. It
+uses the same Stage inventory, origin diagnostics, cancellation, and settlement
+barrier as `adopt()`. It does not return a copied task facade.
 
 `adopt()` attaches an already scheduled task from the selected caller loop to
 Stage cancellation, origin diagnostics, and settlement:
@@ -256,12 +287,14 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
+Use `create_task()` when Stage is responsible for creating the work. Reserve
+`adopt()` for a task that genuinely existed before the ownership handoff.
 An adopted task has already been scheduled by its loop, so
 `max_concurrency`/`max_pending` cannot honestly delay it. Those admission limits
-apply to roots created by `Stage.go()`. `adopt()` returns the original task:
-the task remains the body-outcome handle, while Stage adds scope ownership,
-origin diagnostics, cancellation, idle tracking, and settlement without
-wrapping it in a second `StageHandle`.
+apply to roots created by `Stage.go()`. `create_task()` and `adopt()` both
+return the original native task: the task remains the body-outcome handle,
+while Stage adds scope ownership, origin diagnostics, cancellation, idle
+tracking, and settlement without wrapping it in a second `StageHandle`.
 
 Adapters that need live adopted-task inventory can read `adopted_count`,
 `adopted_tasks`, and `origin_for_adopted(task)`. A Stage can also receive one
@@ -283,9 +316,11 @@ classification, retry, persistence, and side effects. Observer failures are
 reported to the task loop's exception handler and do not reinterpret the task
 outcome or Stage settlement.
 
-`LocalTaskScope` remains importable in the 0.3 line only as a deprecated compatibility
-facade over `Stage`. It emits `DeprecationWarning` and is scheduled for removal
-in 0.4.0. New code should use `Stage.go()` or `Stage.adopt()`.
+`LocalTaskScope` remains importable in the 0.3 line only as a deprecated
+compatibility facade over `Stage`. It emits `DeprecationWarning`, delegates
+task creation and inventory directly to Stage, and is scheduled for removal in
+0.4.0. New code should use `Stage.go()`, `Stage.create_task()`, or
+`Stage.adopt()`.
 
 ### Pressure and idle budgets
 

--- a/agently_stage/LocalTaskScope.py
+++ b/agently_stage/LocalTaskScope.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextvars
 import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -53,9 +52,7 @@ class LocalTaskScope:
             stacklevel=2,
         )
         self._loop: asyncio.AbstractEventLoop | None = None
-        self._stage: Stage | None = None
-        self._adopted: set[asyncio.Task[Any]] = set()
-        self._origins: dict[asyncio.Task[Any], str] = {}
+        self._stage = Stage(on_adopted_done=self._task_done)
         self._on_done = on_done
         self._closed = False
         self._close_completed = False
@@ -64,15 +61,12 @@ class LocalTaskScope:
         loop = asyncio.get_running_loop()
         if self._loop is None:
             self._loop = loop
-            self._stage = Stage(loop=loop, on_adopted_done=self._task_done)
         elif self._loop is not loop:
             raise StageLifecycleError("A local Stage task scope cannot cross event loops")
         return loop
 
     def _bound_stage(self) -> Stage:
         self._bind_running_loop()
-        if self._stage is None:
-            raise StageLifecycleError("Local Stage task scope did not bind its Stage")
         return self._stage
 
     def spawn(
@@ -83,10 +77,8 @@ class LocalTaskScope:
     ) -> asyncio.Task[T]:
         if self._closed:
             raise StageClosedError("Cannot submit work to a closed local Stage task scope")
-        loop = self._bind_running_loop()
-        context = contextvars.copy_context()
-        task = context.run(loop.create_task, coroutine)
-        return self.adopt(task, origin=origin)
+        self._bind_running_loop()
+        return self._stage.create_task(coroutine, origin=origin)
 
     def adopt(
         self,
@@ -99,22 +91,9 @@ class LocalTaskScope:
         stage = self._bound_stage()
         if task.get_loop() is not self._loop:
             raise StageLifecycleError("A local Stage task scope cannot adopt a task from another event loop")
-        if task in self._adopted:
-            registered_origin = self._origins[task]
-            if registered_origin != origin:
-                raise StageLifecycleError(
-                    f"A local Stage task cannot be adopted with two origins: {registered_origin!r} and {origin!r}"
-                )
-            return task
-
-        stage.adopt(task, origin=origin)
-        self._adopted.add(task)
-        self._origins[task] = origin
-        return task
+        return stage.adopt(task, origin=origin)
 
     def _task_done(self, task: asyncio.Task[Any], origin: str) -> None:
-        self._origins.pop(task, None)
-        self._adopted.discard(task)
         cancelled = task.cancelled()
         error = None if cancelled else task.exception()
         if self._on_done is None:
@@ -164,15 +143,21 @@ class LocalTaskScope:
 
     @property
     def pending_count(self) -> int:
-        return len(self._adopted)
+        return self._stage.adopted_count
 
     @property
     def pending_tasks(self) -> tuple[asyncio.Task[Any], ...]:
-        return tuple(self._adopted)
+        return self._stage.adopted_tasks
 
     @property
     def pending_origins(self) -> tuple[str, ...]:
-        return tuple(sorted(self._origins.values()))
+        return tuple(
+            sorted(
+                origin
+                for task in self._stage.adopted_tasks
+                if (origin := self._stage.origin_for_adopted(task)) is not None
+            )
+        )
 
     def origin_for(self, task: asyncio.Task[Any]) -> str | None:
-        return self._origins.get(task)
+        return self._stage.origin_for_adopted(task)

--- a/agently_stage/Stage.py
+++ b/agently_stage/Stage.py
@@ -28,7 +28,7 @@ from .StageHandle import StageHandle
 
 if TYPE_CHECKING:
     from asyncio import AbstractEventLoop, Task
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Awaitable, Callable, Coroutine
 
     from .StageStream import StageStream
 
@@ -604,6 +604,52 @@ class Stage:
         function = task.func if isinstance(task, functools.partial) else task
         name = getattr(function, "__qualname__", None) or getattr(function, "__name__", None)
         return sys.intern(f"go:{name or type(function).__name__}")
+
+    def create_task(
+        self,
+        coroutine: Coroutine[Any, Any, T],
+        *,
+        origin: str,
+        name: str | None = None,
+    ) -> Task[T]:
+        """Create and own one native task on the active caller event loop."""
+
+        if not inspect.iscoroutine(coroutine):
+            raise TypeError("Stage.create_task requires a coroutine object")
+
+        try:
+            loop = asyncio.get_running_loop()
+            with self._scope_lock:
+                owned_nested = _active_stage.get() is self
+                if self._sealed and not owned_nested:
+                    raise StageClosedError("Cannot create a task in a sealed Stage scope")
+                backend, selected_loop = self._resolve_backend_locked()
+                if backend != "caller" or selected_loop is not loop:
+                    lease = self._release_backend_if_quiescent_locked()
+                    if lease is not None:
+                        _RUNTIME_CARRIER.release_lease(lease)
+                    raise StageLifecycleError(
+                        "Stage.create_task requires the current running caller event loop backend"
+                    )
+        except BaseException:
+            coroutine.close()
+            raise
+
+        context = contextvars.copy_context()
+        try:
+            if name is None:
+                task = context.run(loop.create_task, coroutine)
+            else:
+                task = context.run(loop.create_task, coroutine, name=name)
+        except BaseException:
+            coroutine.close()
+            raise
+
+        try:
+            return self.adopt(task, origin=origin)
+        except BaseException:
+            task.cancel()
+            raise
 
     def adopt(self, task: Task[T], *, origin: str) -> Task[T]:
         if not isinstance(cast("Any", task), asyncio.Task):

--- a/examples/caller_loop_task_ownership.py
+++ b/examples/caller_loop_task_ownership.py
@@ -1,0 +1,37 @@
+import asyncio
+
+from agently_stage import Stage
+
+
+async def main() -> None:
+    completed: list[tuple[str, bool]] = []
+
+    def observe(task: asyncio.Task[object], origin: str) -> None:
+        completed.append((origin, task.cancelled()))
+
+    async def owned_work(value: int) -> int:
+        await asyncio.sleep(0)
+        return value * 2
+
+    stage = Stage(on_adopted_done=observe)
+    created = stage.create_task(
+        owned_work(21),
+        origin="example:created",
+        name="stage-created-work",
+    )
+
+    existing = asyncio.create_task(owned_work(5))
+    assert stage.adopt(existing, origin="example:adopted") is existing
+
+    print(await created)
+    print(await existing)
+    await stage.async_close(timeout=1)
+    print(sorted(completed))
+
+
+asyncio.run(main())
+
+# Expected key output from a real local run:
+# 42
+# 10
+# [('example:adopted', False), ('example:created', False)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agently-stage"
-version = "0.3.4"
+version = "0.3.5"
 description = "Agently Stage - Efficient Convenient Asynchronous and Multithreaded Programming"
 authors = [
     { name = "Agently Team", email = "developer@agently.tech" },

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -18,6 +18,7 @@ EXAMPLES = [
     REPOSITORY_ROOT / "examples" / "call_bridge.py",
     REPOSITORY_ROOT / "examples" / "event_emitter.py",
     REPOSITORY_ROOT / "examples" / "automatic_process_exit.py",
+    REPOSITORY_ROOT / "examples" / "caller_loop_task_ownership.py",
 ]
 EXPECTED_OUTPUT_MARKER = "# Expected key output from a real local run:"
 

--- a/tests/test_runtime/test_local_task_scope_shim.py
+++ b/tests/test_runtime/test_local_task_scope_shim.py
@@ -18,5 +18,7 @@ def test_local_task_scope_is_a_deprecated_stage_compatibility_shim() -> None:
 
         assert scope.pending_count == 0
         assert not hasattr(scope, "_tasks")
+        assert not hasattr(scope, "_adopted")
+        assert not hasattr(scope, "_origins")
 
     asyncio.run(run())

--- a/tests/test_runtime/test_stage_scope_backend.py
+++ b/tests/test_runtime/test_stage_scope_backend.py
@@ -261,6 +261,67 @@ def test_adopt_owns_task_outcome_origin_and_settlement() -> None:
     asyncio.run(run())
 
 
+def test_create_task_enters_stage_inventory_with_native_task_identity_and_context() -> None:
+    async def run() -> None:
+        marker = contextvars.ContextVar("stage_task_marker", default="missing")
+        observed: list[tuple[asyncio.Task[tuple[str, int]], str]] = []
+
+        def observe(task: asyncio.Task[tuple[str, int]], origin: str) -> None:
+            observed.append((task, origin))
+
+        stage = Stage(on_adopted_done=observe)
+        caller_loop = asyncio.get_running_loop()
+
+        async def read_context() -> tuple[str, int]:
+            await asyncio.sleep(0)
+            return marker.get(), id(asyncio.get_running_loop())
+
+        token = marker.set("caller")
+        try:
+            task = stage.create_task(read_context(), origin="flow:handler:read-context")
+        finally:
+            marker.reset(token)
+
+        assert isinstance(task, asyncio.Task)
+        assert stage.adopted_tasks == (task,)
+        assert stage.origin_for_adopted(task) == "flow:handler:read-context"
+        assert await task == ("caller", id(caller_loop))
+        await stage.async_wait_settled(timeout=1)
+        assert observed == [(task, "flow:handler:read-context")]
+        await stage.async_close()
+
+    asyncio.run(run())
+
+
+def test_create_task_rejects_non_caller_backend_and_closes_coroutine() -> None:
+    async def run() -> None:
+        stage = Stage(loop="stage")
+        coroutine = asyncio.sleep(0)
+
+        with pytest.raises(StageLifecycleError, match="caller"):
+            stage.create_task(coroutine, origin="flow:wrong-backend")
+
+        assert coroutine.cr_frame is None
+        await stage.async_close()
+
+    asyncio.run(run())
+
+
+def test_create_task_rejects_sealed_scope_without_leaking_coroutine() -> None:
+    async def run() -> None:
+        stage = Stage()
+        stage.seal()
+        coroutine = asyncio.sleep(0)
+
+        with pytest.raises(StageClosedError):
+            stage.create_task(coroutine, origin="flow:late")
+
+        assert coroutine.cr_frame is None
+        await stage.async_close()
+
+    asyncio.run(run())
+
+
 def test_adopted_inventory_and_observer_settle_as_one_stage_operation() -> None:
     async def run() -> None:
         observed: list[tuple[asyncio.Task[bool], str, int]] = []


### PR DESCRIPTION
## Summary

- add `Stage.create_task(...)` for native caller-loop task creation and ownership
- keep task identity, origin diagnostics, cancellation, settlement, and close in one Stage inventory
- reduce `LocalTaskScope` to a deprecated compatibility shim with no shadow registry
- add runnable documentation and regression coverage

## Validation

- `python -m pytest -q`: 195 passed, 1 skipped
- `pyright`: 0 errors
- wheel and sdist build: passed
- distribution metadata check: passed
- isolated wheel install and `create_task` settlement smoke: passed

## Release

This PR prepares `agently-stage` 0.3.5. Agently 4.1.4.5 depends on `agently-stage >=0.3.5,<0.4.0`.