### PR TITLE
fix: automatically route mixed sync/async Stage scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ The first admitted root in each active epoch selects its backend lazily:
 - after complete settlement, a reusable automatic Stage releases the binding
   and selects again when later work arrives.
 
-The Stage carrier uses one process-wide control worker with finite asyncio loop
-generations. Retained work drains, its loop closes, and a later batch can open a
-new generation. Ordinary scripts do not need a process shutdown hook.
+The Stage carrier uses a finite process-wide pool of lazy asyncio loop lanes.
+The default pool has one control worker. Retained work drains, its loop closes,
+and a later batch can open a new generation. Ordinary scripts do not need a
+process shutdown hook.
 
 ## Install
 
@@ -74,6 +75,22 @@ used to request cancellation without claiming settlement.
 
 Stage never stops or closes a caller-owned event loop and never replaces its
 task factory. Calling `asyncio.run()` before or after Stage remains valid.
+
+A synchronous context deliberately requests a synchronous boundary. Therefore
+`with Stage()` inside a running async function selects a safe carrier instead
+of binding work to the event loop that the context will block:
+
+```python
+async def compatibility_entry() -> str:
+    with Stage() as stage:
+        return stage.get(fetch)
+```
+
+This form is supported for compatibility, but it still blocks the calling
+thread. Native async code should normally use `async with Stage()` and await the
+handle. Work that owns objects bound to the blocked caller loop cannot be moved
+safely; use `await` for that work. An explicitly supplied exact loop is never
+silently redirected.
 
 Backend selection can also be explicit:
 
@@ -209,11 +226,13 @@ One active epoch never spans multiple loops. Cross-thread submissions during an
 active epoch are delivered to that epoch's selected loop. Complete settlement
 releases an automatic binding; the next root selects again.
 
-`with Stage()` and `async with Stage()` are lifecycle conveniences. Context exit
-seals the scope and waits for its work, but context entry does not pin an
-automatic Stage to a carrier generation. Use `Stage(loop="stage")` or an exact
-loop object when the backend policy must be pinned. An empty context creates no
-loop.
+`with Stage()` and `async with Stage()` are lifecycle conveniences. A sync
+context selects a physically safe carrier; an async context prefers its current
+running loop. Context exit seals the scope and waits for Stage-owned work. An
+empty context creates no loop. Nested automatic sync scopes reuse an inherited
+carrier when the caller is a worker; if the caller physically runs the only
+eligible carrier loop, Stage uses a temporary escape carrier rather than
+deadlocking. The logical scopes and settlement inventories remain independent.
 
 `Stage.close()` and `Stage.async_close()` are scope barriers for explicit
 application lifecycles. They are not required to make an ordinary script exit:
@@ -354,10 +373,65 @@ types.
 Stage is a task-lifetime mechanism, not an event bus, workflow runtime, tenant
 boundary, provider cancellation acknowledgement, or business retry policy.
 
-## StageCallBridge
+## Scoped sync/async adapters
+
+Use the class-level adapters when a provider deliberately exposes the opposite
+call shape. Each invocation owns one automatic Stage scope, so the body result
+is returned only after that scope's Stage-owned work settles:
+
+```python
+async def fetch_name(identifier: int) -> str:
+    await asyncio.sleep(0)
+    return f"user-{identifier}"
+
+
+fetch_name_sync = Stage.as_sync(fetch_name)
+assert fetch_name_sync(7) == "user-7"
+
+
+async def main() -> None:
+    calculate_async = Stage.as_async(lambda value: value * 2)
+    assert await calculate_async(21) == 42
+```
+
+`Stage.as_sync()` and `Stage.as_async()` preserve callable metadata and accept
+callables that return awaitables dynamically. They adapt scalar calls only;
+use `StageCallBridge.iter_sync()` / `iter_async()` for stream conversion. They
+do not expose a `managed` switch because the Stage scope owns settlement by
+definition.
+
+Choose the smallest matching entry:
+
+| Caller need | Recommended entry | Runtime behavior |
+|---|---|---|
+| native async call | direct `await` | stays on the caller loop |
+| explicit async lifetime scope | `async with Stage()` | caller loop plus async settlement |
+| deliberate synchronous boundary | `with Stage()` or `Stage.as_sync()` | safe carrier; calling thread blocks |
+| deliberate asynchronous view of sync code | `Stage.as_async()` | blocking executor plus async settlement |
+| injected resources, light adaptation, or stream conversion | `StageCallBridge` | advanced explicit bridge lifecycle |
+
+### Carrier pool setting
+
+The normal carrier pool defaults to one loop lane. Applications that have
+measured one carrier as a bottleneck may configure a larger finite pool before
+the first carrier lease:
+
+```python
+Stage.set_settings("runtime.carrier_loop_count", 4)
+```
+
+New Stage epochs reuse a safe inherited carrier when possible; otherwise they
+select a lower-pressure lane and remain sticky until settlement. Equal-pressure
+selection rotates across lanes. The setting must be a positive integer and is
+frozen after first carrier use; setting the same value again is allowed, while
+changing it requires a process restart. It controls carrier loop threads, not
+blocking `max_workers`, application admission, or coroutine concurrency.
+
+## Advanced StageCallBridge
 
 `StageCallBridge` adapts call shape at sync/async boundaries without making
-application event, retry, or workflow decisions.
+application event, retry, or workflow decisions. Most application code should
+prefer the scoped `Stage.as_sync()` / `Stage.as_async()` facade above.
 
 ```python
 import asyncio
@@ -598,6 +672,7 @@ run:
 - [Callbacks, errors, and cancellation](examples/callbacks_errors_and_cancellation.py)
 - [Tunnel broadcast, timeout, and failure](examples/tunnel_broadcast.py)
 - [StageStream lazy execution, replay, and failure](examples/stage_stream.py)
+- [Automatic sync/async scopes and adapters](examples/automatic_environment.py)
 - [Call-shape bridging and early stream close](examples/call_bridge.py)
 - [EventEmitter listeners without ordinary close](examples/event_emitter.py)
 - [Automatic process exit after retained work](examples/automatic_process_exit.py)
@@ -606,7 +681,7 @@ run:
 
 - Async callables remain concurrent on one active backend loop; the shared
   carrier control worker is not a serial task executor.
-- Stage scopes share the process-wide carrier. A scope is a lifetime and
+- Stage scopes share the process-wide carrier pool. A scope is a lifetime and
   settlement boundary, not a tenant, fault, process, or resource-isolation
   boundary.
 - Blocking functions and synchronous generator stepping use a separate blocking

--- a/agently_stage/Stage.py
+++ b/agently_stage/Stage.py
@@ -10,10 +10,10 @@ import threading
 import time
 import types
 from collections import deque
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Iterator
 from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, ParamSpec, TypeVar, cast, overload
 
 from ._runtime import _RUNTIME_CARRIER, _Generation, _WorkPhase
 from .StageException import (
@@ -28,13 +28,14 @@ from .StageHandle import StageHandle
 
 if TYPE_CHECKING:
     from asyncio import AbstractEventLoop, Task
-    from collections.abc import Awaitable, Callable, Coroutine
 
     from .StageStream import StageStream
 
 T = TypeVar("T")
 StreamT = TypeVar("StreamT")
+P = ParamSpec("P")
 _BackendKind = Literal["caller", "stage"]
+_ContextMode = Literal["sync", "async"]
 
 
 class _AutoLoop:
@@ -78,6 +79,71 @@ _IMMEDIATE_ROOT_ADMISSION = _RootAdmission(gate=None, granted=True)
 
 class Stage:
     """A structured scope whose work may use a caller loop or the Stage carrier."""
+
+    @classmethod
+    def set_settings(cls, key: str, value: object) -> type[Stage]:
+        """Set one process-level Stage runtime option before carrier use."""
+
+        if key != "runtime.carrier_loop_count":
+            raise KeyError(f"Unknown Stage setting: {key}")
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError("runtime.carrier_loop_count must be a positive integer")
+        if value <= 0:
+            raise ValueError("runtime.carrier_loop_count must be greater than zero")
+        _RUNTIME_CARRIER.set_carrier_loop_count(value)
+        return cls
+
+    @classmethod
+    def as_sync(
+        cls,
+        function: Callable[P, T | Awaitable[T]],
+    ) -> Callable[P, T]:
+        """Expose a callable through one automatically routed synchronous scope."""
+
+        if not callable(function):
+            raise TypeError(f"Expected a callable, got {type(function)}")
+        if inspect.isasyncgenfunction(function) or inspect.isgeneratorfunction(function):
+            raise TypeError("Stage.as_sync accepts scalar callables; use StageCallBridge.iter_sync for streams")
+
+        @functools.wraps(function)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            with cls() as stage:
+                response = stage.go(function, *args, **kwargs)
+                from .StageStream import StageStream
+
+                if isinstance(response, StageStream):
+                    response.close()
+                    raise TypeError("Stage.as_sync accepts scalar callables; use StageCallBridge.iter_sync for streams")
+                return cast("StageHandle[T]", response).get()
+
+        return wrapper
+
+    @classmethod
+    def as_async(
+        cls,
+        function: Callable[P, T | Awaitable[T]],
+    ) -> Callable[P, Coroutine[Any, Any, T]]:
+        """Expose a callable through one automatically routed asynchronous scope."""
+
+        if not callable(function):
+            raise TypeError(f"Expected a callable, got {type(function)}")
+        if inspect.isasyncgenfunction(function) or inspect.isgeneratorfunction(function):
+            raise TypeError("Stage.as_async accepts scalar callables; use StageCallBridge.iter_async for streams")
+
+        @functools.wraps(function)
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            async with cls() as stage:
+                response = stage.go(function, *args, **kwargs)
+                from .StageStream import StageStream
+
+                if isinstance(response, StageStream):
+                    await response.async_close()
+                    raise TypeError(
+                        "Stage.as_async accepts scalar callables; use StageCallBridge.iter_async for streams"
+                    )
+                return await cast("StageHandle[T]", response).async_get()
+
+        return wrapper
 
     @overload
     def __init__(
@@ -162,6 +228,7 @@ class Stage:
         self._generation_lease: _Generation | None = None
         self._active_backend: _BackendKind | None = None
         self._active_loop: AbstractEventLoop | None = None
+        self._context_mode: _ContextMode | None = None
 
         if isinstance(loop, _AutoLoop):
             self._backend_mode: Literal["auto", "caller", "stage"] = "auto"
@@ -224,16 +291,22 @@ class Stage:
             backend = "stage"
             loop = None
         else:
-            try:
-                loop = asyncio.get_running_loop()
-            except RuntimeError:
+            if self._context_mode == "sync":
                 backend = "stage"
                 loop = None
             else:
-                backend = "caller"
+                try:
+                    loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    backend = "stage"
+                    loop = None
+                else:
+                    backend = "caller"
 
         if backend == "stage":
-            self._generation_lease = _RUNTIME_CARRIER.acquire_lease()
+            self._generation_lease = _RUNTIME_CARRIER.acquire_lease(
+                avoid_current_loop=self._context_mode == "sync",
+            )
         self._active_backend = backend
         self._active_loop = loop
         return backend, loop
@@ -273,6 +346,20 @@ class Stage:
         if admission is not None and admission.gate is not None:
             await asyncio.shield(asyncio.wrap_future(admission.gate))
 
+    async def _await_with_loop_affinity_guidance(self, awaitable: Awaitable[T]) -> T:
+        try:
+            return await awaitable
+        except RuntimeError as error:
+            message = str(error).lower()
+            if self._active_backend == "stage" and (
+                "attached to a different loop" in message or "bound to a different event loop" in message
+            ):
+                raise StageLifecycleError(
+                    "This work depends on an object bound to another event loop and cannot run on the selected "
+                    "Stage carrier; use 'async with Stage()' and await it on the object's owner loop"
+                ) from error
+            raise
+
     def _finish_admission(self, admission: _RootAdmission | None) -> None:
         if admission is None:
             return
@@ -302,13 +389,13 @@ class Stage:
         kwargs: dict[str, Any],
     ) -> T:
         if isinstance(task, Future):
-            return await asyncio.wrap_future(cast("Future[T]", task))
+            return await self._await_with_loop_affinity_guidance(asyncio.wrap_future(cast("Future[T]", task)))
         if inspect.isawaitable(task):
             if args or kwargs:
                 raise TypeError("Arguments cannot be supplied with a coroutine object")
-            return await cast("Awaitable[T]", task)
+            return await self._await_with_loop_affinity_guidance(cast("Awaitable[T]", task))
         if inspect.iscoroutinefunction(task):
-            return await task(*args, **kwargs)
+            return await self._await_with_loop_affinity_guidance(task(*args, **kwargs))
 
         loop = asyncio.get_running_loop()
         context = contextvars.copy_context()
@@ -320,7 +407,7 @@ class Stage:
             await asyncio.shield(blocking_future)
             raise
         if inspect.isawaitable(result):
-            return await cast("Awaitable[T]", result)
+            return await self._await_with_loop_affinity_guidance(cast("Awaitable[T]", result))
         return cast("T", result)
 
     async def _execute_callback(
@@ -1147,16 +1234,56 @@ class Stage:
         with self._scope_lock:
             if self._sealed:
                 raise StageClosedError("Cannot enter a sealed Stage scope")
+            if self._context_mode is not None:
+                raise StageLifecycleError("A Stage scope cannot be entered more than once")
+            self._context_mode = "sync"
         return self
 
     def __exit__(self, exc_type: object, value: BaseException | None, traceback: object) -> None:
-        self.close()
+        self.seal()
+        if value is None:
+            self.close()
+            return
+        try:
+            self.close()
+        except BaseException as cleanup_error:
+            cleanup_error.__context__ = None
+            value.__context__ = cleanup_error
+            if isinstance(cleanup_error, StageLifecycleError):
+                try:
+                    loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    return
+                deferred_close = loop.run_in_executor(None, self.close)
+
+                def observe_deferred_close(future: asyncio.Future[None]) -> None:
+                    try:
+                        future.result()
+                    except BaseException as deferred_error:
+                        deferred_error.__context__ = None
+                        value.__context__ = deferred_error
+
+                deferred_close.add_done_callback(observe_deferred_close)
 
     async def __aenter__(self) -> Stage:  # noqa: PYI034
-        return self.__enter__()
+        with self._scope_lock:
+            if self._sealed:
+                raise StageClosedError("Cannot enter a sealed Stage scope")
+            if self._context_mode is not None:
+                raise StageLifecycleError("A Stage scope cannot be entered more than once")
+            self._context_mode = "async"
+        return self
 
     async def __aexit__(self, exc_type: object, value: BaseException | None, traceback: object) -> None:
-        await self.async_close()
+        self.seal()
+        if value is None:
+            await self.async_close()
+            return
+        try:
+            await self.async_close()
+        except BaseException as cleanup_error:
+            cleanup_error.__context__ = None
+            value.__context__ = cleanup_error
 
     def func(self, task: Callable[..., T]) -> StageFunction[T]:
         return StageFunction(self, task)

--- a/agently_stage/StageCallBridge.py
+++ b/agently_stage/StageCallBridge.py
@@ -8,12 +8,21 @@ import inspect
 import threading
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
 
+from ._runtime import _RUNTIME_CARRIER
 from .Stage import Stage
 from .StageException import StageLifecycleError
 from .StageStream import StageStream
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Coroutine, Generator, Iterator
+    from collections.abc import (
+        AsyncGenerator,
+        AsyncIterator,
+        Awaitable,
+        Callable,
+        Coroutine,
+        Generator,
+        Iterator,
+    )
     from concurrent.futures import Executor
 
     from .StageHandle import StageHandle
@@ -54,7 +63,7 @@ class StageCallBridge:
         return callable(function) and inspect.iscoroutinefunction(function.__call__)
 
     def _resolve_awaitable_sync(self, awaitable: Awaitable[T], *, managed: bool) -> T:
-        if self._carrier_stage.owns_current_execution():
+        if _RUNTIME_CARRIER.would_sync_wait_block_current_carrier(self._carrier_stage):
             close = getattr(awaitable, "close", None)
             if close is not None:
                 close()
@@ -89,7 +98,7 @@ class StageCallBridge:
         @functools.wraps(function)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             self._ensure_open()
-            if async_callable and self._carrier_stage.owns_current_execution():
+            if async_callable and _RUNTIME_CARRIER.would_sync_wait_block_current_carrier(self._carrier_stage):
                 raise StageLifecycleError(
                     "A synchronous StageCallBridge call cannot re-enter and block its own carrier execution"
                 )

--- a/agently_stage/_runtime.py
+++ b/agently_stage/_runtime.py
@@ -40,6 +40,9 @@ class _RuntimeSnapshot:
     queued_generation_id: int | None
     active_loop_count: int
     control_thread_count: int
+    carrier_loop_count: int
+    escape_loop_count: int
+    active_generation_ids: tuple[int, ...]
 
 
 @dataclass
@@ -54,6 +57,7 @@ class _Submission:
 @dataclass
 class _Generation:
     generation_id: int
+    slot_id: int
     state: _GenerationState = _GenerationState.QUEUED
     reservations: int = 0
     loop: AbstractEventLoop | None = None
@@ -74,26 +78,26 @@ _active_execution: contextvars.ContextVar[_ExecutionContext | None] = contextvar
 )
 
 
-class _RuntimeCarrier:
-    """Process-local owner of finite Stage event-loop generations."""
+class _CarrierSlot:
+    """One finite carrier-loop lane owned by the process runtime."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        slot_id: int,
+        allocate_generation_id: Callable[[], int],
+        *,
+        on_idle: Callable[[_CarrierSlot], None] | None = None,
+    ) -> None:
+        self.slot_id = slot_id
+        self._allocate_generation_id = allocate_generation_id
+        self._on_idle = on_idle
         self._admission_lock = threading.RLock()
-        self._control_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="AgentlyStageControl")
-        self._blocking_executor = ThreadPoolExecutor(thread_name_prefix="AgentlyStageBlocking")
+        self._control_executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix=f"AgentlyStageControl-{slot_id}",
+        )
         self._current: _Generation | None = None
         self._next: _Generation | None = None
-        self._generation_counter = 0
-
-    @property
-    def blocking_executor(self) -> ThreadPoolExecutor:
-        return self._blocking_executor
-
-    def owns_current_execution(self, stage: Stage) -> bool:
-        """Return whether the caller is executing work retained by ``stage``."""
-
-        context = _active_execution.get()
-        return context is not None and context.handle._stage is stage
 
     def submit(
         self,
@@ -127,14 +131,14 @@ class _RuntimeCarrier:
             handle._release_work()
             raise
 
-    def acquire_lease(self) -> _Generation:
+    def acquire_lease(self, preferred: _Generation | None = None) -> _Generation:
         with self._admission_lock:
-            return self._reserve_locked(None)
+            return self._reserve_locked(preferred)
 
     def release_lease(self, generation: _Generation) -> None:
         self._release_reservation(generation)
 
-    def snapshot(self) -> _RuntimeSnapshot:
+    def snapshot(self) -> tuple[int | None, int | None, int, int]:
         with self._admission_lock:
             current = self._current
             queued = self._next
@@ -143,40 +147,22 @@ class _RuntimeCarrier:
             active_loop_count = sum(
                 generation is not None and generation.loop is not None for generation in (current, queued)
             )
-        control_thread_count = sum(thread.name.startswith("AgentlyStageControl") for thread in threading.enumerate())
-        return _RuntimeSnapshot(
-            active_generation_id=current_id,
-            queued_generation_id=queued_id,
-            active_loop_count=active_loop_count,
-            control_thread_count=control_thread_count,
-        )
-
-    def create_settlement_task(self, coroutine: Any) -> Task[Any]:
-        """Create one retained task in the active handle's settlement phase."""
-
-        context = _active_execution.get()
-        if context is None:
-            raise StageLifecycleError("Settlement task requires active Stage execution")
-        token = _active_execution.set(
-            _ExecutionContext(
-                generation=context.generation,
-                handle=context.handle,
-                phase=_WorkPhase.SETTLEMENT,
+            reservations = sum(
+                generation.reservations
+                for generation in (current, queued)
+                if generation is not None and generation.state is not _GenerationState.CLOSED
             )
-        )
-        try:
-            return asyncio.create_task(coroutine)
-        finally:
-            _active_execution.reset(token)
+        return current_id, queued_id, active_loop_count, reservations
 
-    def bind_current_execution(self, context: contextvars.Context) -> contextvars.Context:
-        """Overlay the active private Stage lineage on a user context snapshot."""
+    def owns_loop(self, loop: AbstractEventLoop) -> bool:
+        with self._admission_lock:
+            return any(generation is not None and generation.loop is loop for generation in (self._current, self._next))
 
-        bound_context = context.copy()
-        execution = _active_execution.get()
-        if execution is not None:
-            bound_context.run(_active_execution.set, execution)
-        return bound_context
+    def owns_generation(self, generation: _Generation) -> bool:
+        return generation.slot_id == self.slot_id
+
+    def shutdown(self) -> None:
+        self._control_executor.shutdown(wait=False)
 
     def _reserve_locked(self, preferred: _Generation | None) -> _Generation:
         if preferred is not None:
@@ -205,8 +191,10 @@ class _RuntimeCarrier:
         return generation
 
     def _create_generation_locked(self, *, as_next: bool) -> _Generation:
-        self._generation_counter += 1
-        generation = _Generation(self._generation_counter)
+        generation = _Generation(
+            generation_id=self._allocate_generation_id(),
+            slot_id=self.slot_id,
+        )
         if as_next:
             self._next = generation
         else:
@@ -287,6 +275,9 @@ class _RuntimeCarrier:
                 if self._current is generation:
                     self._current = self._next
                     self._next = None
+                became_idle = self._current is None and self._next is None
+            if became_idle and self._on_idle is not None:
+                self._on_idle(self)
 
     def _start_submission(self, generation: _Generation, submission: _Submission) -> None:
         loop = generation.loop
@@ -372,6 +363,220 @@ class _RuntimeCarrier:
         handle._stage._owned_activity()
         self._release_reservation(generation)
         handle._release_work()
+
+
+class _RuntimeCarrier:
+    """Process-local finite pool of lazy carrier-loop slots."""
+
+    def __init__(self) -> None:
+        self._pool_lock = threading.RLock()
+        self._blocking_executor = ThreadPoolExecutor(thread_name_prefix="AgentlyStageBlocking")
+        self._generation_counter = 0
+        self._slot_counter = 0
+        self._selection_cursor = 0
+        self._carrier_loop_count = 1
+        self._settings_frozen = False
+        self._slots: list[_CarrierSlot] = [self._new_slot_locked()]
+        self._escape_slots: dict[int, _CarrierSlot] = {}
+
+    @property
+    def blocking_executor(self) -> ThreadPoolExecutor:
+        return self._blocking_executor
+
+    def set_carrier_loop_count(self, count: int) -> None:
+        retired: list[_CarrierSlot] = []
+        with self._pool_lock:
+            if self._settings_frozen:
+                if count == self._carrier_loop_count:
+                    return
+                raise StageLifecycleError(
+                    "runtime.carrier_loop_count is frozen after the first carrier lease; restart the process to change it"
+                )
+            while len(self._slots) < count:
+                self._slots.append(self._new_slot_locked())
+            while len(self._slots) > count:
+                retired.append(self._slots.pop())
+            self._carrier_loop_count = count
+            self._selection_cursor %= count
+        for slot in retired:
+            slot.shutdown()
+
+    def owns_current_execution(self, stage: Stage) -> bool:
+        """Return whether logical execution lineage belongs to ``stage``."""
+
+        context = _active_execution.get()
+        return context is not None and context.handle._stage is stage
+
+    def would_sync_wait_block_current_carrier(self, stage: Stage) -> bool:
+        """Return whether ``stage`` would target the carrier loop now executing."""
+
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return False
+        with stage._scope_lock:
+            generation = stage._generation_lease
+            active_backend = stage._active_backend
+        if active_backend == "stage" and generation is not None:
+            return generation.loop is running_loop
+
+        # An unbound carrier Stage inherits the physically active generation on
+        # first lease. Context propagation into a blocking worker is harmless:
+        # such a worker has no running loop and returned above.
+        context = _active_execution.get()
+        return active_backend is None and context is not None and context.generation.loop is running_loop
+
+    def submit(
+        self,
+        handle: StageHandle[Any],
+        runner: Callable[[_Generation], Awaitable[None]],
+        *,
+        preferred: _Generation | None = None,
+        owner: bool = True,
+        phase: _WorkPhase = _WorkPhase.BODY,
+    ) -> int:
+        if preferred is None:
+            slot = self._select_slot(avoid_current_loop=False)
+        else:
+            slot = self._slot_for_generation(preferred)
+        return slot.submit(
+            handle,
+            runner,
+            preferred=preferred,
+            owner=owner,
+            phase=phase,
+        )
+
+    def acquire_lease(self, *, avoid_current_loop: bool = False) -> _Generation:
+        self._freeze_settings()
+        inherited = _active_execution.get()
+        if inherited is not None and not self._generation_is_current_loop(
+            inherited.generation,
+            only_when=avoid_current_loop,
+        ):
+            try:
+                return self._slot_for_generation(inherited.generation).acquire_lease(inherited.generation)
+            except StageLifecycleError:
+                pass
+        return self._select_slot(avoid_current_loop=avoid_current_loop).acquire_lease()
+
+    def release_lease(self, generation: _Generation) -> None:
+        self._slot_for_generation(generation).release_lease(generation)
+
+    def create_settlement_task(self, coroutine: Any) -> Task[Any]:
+        """Create one retained task in the active handle's settlement phase."""
+
+        context = _active_execution.get()
+        if context is None:
+            raise StageLifecycleError("Settlement task requires active Stage execution")
+        token = _active_execution.set(
+            _ExecutionContext(
+                generation=context.generation,
+                handle=context.handle,
+                phase=_WorkPhase.SETTLEMENT,
+            )
+        )
+        try:
+            return asyncio.create_task(coroutine)
+        finally:
+            _active_execution.reset(token)
+
+    def bind_current_execution(self, context: contextvars.Context) -> contextvars.Context:
+        """Overlay the active private Stage lineage on a user context snapshot."""
+
+        bound_context = context.copy()
+        execution = _active_execution.get()
+        if execution is not None:
+            bound_context.run(_active_execution.set, execution)
+        return bound_context
+
+    def snapshot(self) -> _RuntimeSnapshot:
+        with self._pool_lock:
+            slots = tuple(self._slots)
+            escape_slots = tuple(self._escape_slots.values())
+            configured_count = self._carrier_loop_count
+        snapshots = [slot.snapshot() for slot in (*slots, *escape_slots)]
+        active_ids = tuple(current_id for current_id, _, _, _ in snapshots if current_id is not None)
+        queued_ids = tuple(queued_id for _, queued_id, _, _ in snapshots if queued_id is not None)
+        active_loop_count = sum(loop_count for _, _, loop_count, _ in snapshots)
+        control_thread_count = sum(thread.name.startswith("AgentlyStageControl") for thread in threading.enumerate())
+        return _RuntimeSnapshot(
+            active_generation_id=active_ids[0] if active_ids else None,
+            queued_generation_id=queued_ids[0] if queued_ids else None,
+            active_loop_count=active_loop_count,
+            control_thread_count=control_thread_count,
+            carrier_loop_count=configured_count,
+            escape_loop_count=len(escape_slots),
+            active_generation_ids=active_ids,
+        )
+
+    def _freeze_settings(self) -> None:
+        with self._pool_lock:
+            self._settings_frozen = True
+
+    def _allocate_generation_id(self) -> int:
+        with self._pool_lock:
+            self._generation_counter += 1
+            return self._generation_counter
+
+    def _new_slot_locked(self, *, escape: bool = False) -> _CarrierSlot:
+        self._slot_counter += 1
+        slot = _CarrierSlot(
+            self._slot_counter,
+            self._allocate_generation_id,
+            on_idle=self._escape_slot_idle if escape else None,
+        )
+        if escape:
+            self._escape_slots[slot.slot_id] = slot
+        return slot
+
+    def _escape_slot_idle(self, slot: _CarrierSlot) -> None:
+        with self._pool_lock:
+            removed = self._escape_slots.pop(slot.slot_id, None)
+        if removed is not None:
+            removed.shutdown()
+
+    def _slot_for_generation(self, generation: _Generation) -> _CarrierSlot:
+        with self._pool_lock:
+            slots = (*self._slots, *self._escape_slots.values())
+        for slot in slots:
+            if slot.owns_generation(generation):
+                return slot
+        raise StageLifecycleError("Stage generation is no longer owned by the carrier pool")
+
+    def _generation_is_current_loop(self, generation: _Generation, *, only_when: bool) -> bool:
+        if not only_when:
+            return False
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return False
+        return generation.loop is running_loop
+
+    def _select_slot(self, *, avoid_current_loop: bool) -> _CarrierSlot:
+        self._freeze_settings()
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+        with self._pool_lock:
+            slots = tuple(self._slots)
+            cursor = self._selection_cursor
+        candidates: list[tuple[int, int, _CarrierSlot]] = []
+        for index, slot in enumerate(slots):
+            if avoid_current_loop and running_loop is not None and slot.owns_loop(running_loop):
+                continue
+            _, _, _, pressure = slot.snapshot()
+            distance = (index - cursor) % len(slots)
+            candidates.append((pressure, distance, slot))
+        if not candidates:
+            with self._pool_lock:
+                return self._new_slot_locked(escape=True)
+        _, _, selected = min(candidates, key=lambda item: (item[0], item[1]))
+        with self._pool_lock:
+            selected_index = self._slots.index(selected)
+            self._selection_cursor = (selected_index + 1) % len(self._slots)
+        return selected
 
 
 _RUNTIME_CARRIER = _RuntimeCarrier()

--- a/examples/automatic_environment.py
+++ b/examples/automatic_environment.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import asyncio
+
+from agently_stage import Stage
+
+# Expected key output from a real local run:
+# sync adapter: user-7
+# async adapter: 42
+# sync context in async caller: user-8
+
+
+async def fetch_name(identifier: int) -> str:
+    await asyncio.sleep(0)
+    return f"user-{identifier}"
+
+
+def calculate(value: int) -> int:
+    return value * 2
+
+
+async def main() -> None:
+    fetch_name_sync = Stage.as_sync(fetch_name)
+    calculate_async = Stage.as_async(calculate)
+
+    # A deliberate sync view works even though this caller already has a loop.
+    print("sync adapter:", fetch_name_sync(7))
+    print("async adapter:", await calculate_async(21))
+
+    # The sync context also selects a carrier rather than blocking its own work.
+    with Stage() as stage:
+        print("sync context in async caller:", stage.get(fetch_name, 8))
+
+
+if __name__ == "__main__":
+    Stage.set_settings("runtime.carrier_loop_count", 1)
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agently-stage"
-version = "0.3.5"
+version = "0.3.6"
 description = "Agently Stage - Efficient Convenient Asynchronous and Multithreaded Programming"
 authors = [
     { name = "Agently Team", email = "developer@agently.tech" },

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -15,6 +15,7 @@ EXAMPLES = [
     REPOSITORY_ROOT / "examples" / "callbacks_errors_and_cancellation.py",
     REPOSITORY_ROOT / "examples" / "tunnel_broadcast.py",
     REPOSITORY_ROOT / "examples" / "stage_stream.py",
+    REPOSITORY_ROOT / "examples" / "automatic_environment.py",
     REPOSITORY_ROOT / "examples" / "call_bridge.py",
     REPOSITORY_ROOT / "examples" / "event_emitter.py",
     REPOSITORY_ROOT / "examples" / "automatic_process_exit.py",

--- a/tests/test_runtime/test_automatic_environment.py
+++ b/tests/test_runtime/test_automatic_environment.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import inspect
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+
+import pytest
+
+from agently_stage import Stage, StageLifecycleError, StageSettlementError
+from agently_stage._runtime import _runtime_snapshot
+
+
+async def _current_loop() -> asyncio.AbstractEventLoop:
+    return asyncio.get_running_loop()
+
+
+def test_sync_context_inside_running_loop_uses_safe_carrier() -> None:
+    async def scenario() -> tuple[str, asyncio.AbstractEventLoop, asyncio.AbstractEventLoop]:
+        caller_loop = asyncio.get_running_loop()
+
+        async def leaf() -> tuple[str, asyncio.AbstractEventLoop]:
+            await asyncio.sleep(0)
+            return "ok", asyncio.get_running_loop()
+
+        with Stage() as stage:
+            value, worker_loop = stage.get(leaf)
+        return value, caller_loop, worker_loop
+
+    value, caller_loop, worker_loop = asyncio.run(scenario())
+
+    assert value == "ok"
+    assert worker_loop is not caller_loop
+
+
+def test_sync_context_explains_loop_affinity_boundary() -> None:
+    async def scenario() -> None:
+        caller_loop = asyncio.get_running_loop()
+        loop_bound = caller_loop.create_future()
+        caller_loop.call_soon(loop_bound.set_result, "ok")
+
+        with Stage() as stage:
+            stage.get(lambda: loop_bound)
+
+    with pytest.raises(StageLifecycleError, match=r"async with Stage\(\).+owner loop"):
+        asyncio.run(scenario())
+
+
+def test_explicit_same_loop_sync_scope_preserves_primary_error() -> None:
+    observed_stages: list[Stage] = []
+
+    async def scenario() -> None:
+        loop = asyncio.get_running_loop()
+        with Stage(loop=loop) as stage:
+            observed_stages.append(stage)
+            stage.get(asyncio.sleep, 0)
+
+    with pytest.raises(StageLifecycleError, match=r"get\(\).+async_get\(\)"):
+        asyncio.run(scenario())
+    assert observed_stages[0].snapshot().state == "closed"
+
+
+def test_stage_as_sync_is_a_scoped_adapter() -> None:
+    marker = contextvars.ContextVar("marker", default="missing")
+    caller_thread = threading.get_ident()
+    child_finished = threading.Event()
+
+    async def work(value: int) -> tuple[int, str, int]:
+        async def retained_child() -> None:
+            await asyncio.sleep(0.01)
+            child_finished.set()
+
+        asyncio.create_task(retained_child())
+        return value, marker.get(), threading.get_ident()
+
+    marker.set("caller")
+    adapted = Stage.as_sync(work)
+
+    assert adapted.__name__ == "work"
+    assert inspect.signature(adapted) == inspect.signature(work)
+    value, observed_marker, worker_thread = adapted(7)
+    assert value == 7
+    assert observed_marker == "caller"
+    assert worker_thread != caller_thread
+    assert child_finished.is_set()
+
+
+def test_stage_adapters_support_decorator_form() -> None:
+    @Stage.as_sync
+    async def sync_view(value: int) -> int:
+        return value
+
+    @Stage.as_async
+    def async_view(value: int) -> int:
+        return value
+
+    assert sync_view(1) == 1
+
+    async def scenario() -> None:
+        assert await async_view(2) == 2
+
+    asyncio.run(scenario())
+
+
+def test_stage_as_async_is_a_scoped_adapter() -> None:
+    marker = contextvars.ContextVar("marker", default="missing")
+
+    def work(value: int) -> tuple[int, str, int]:
+        return value, marker.get(), threading.get_ident()
+
+    async def scenario() -> None:
+        caller_thread = threading.get_ident()
+        marker.set("caller")
+        adapted = Stage.as_async(work)
+
+        assert adapted.__name__ == "work"
+        assert inspect.signature(adapted) == inspect.signature(work)
+        value, observed_marker, worker_thread = await adapted(7)
+        assert value == 7
+        assert observed_marker == "caller"
+        assert worker_thread != caller_thread
+
+    asyncio.run(scenario())
+
+
+def test_sync_context_on_carrier_uses_an_escape_loop() -> None:
+    outer = Stage(loop="stage")
+
+    async def run_nested_scope() -> tuple[asyncio.AbstractEventLoop, asyncio.AbstractEventLoop]:
+        outer_loop = asyncio.get_running_loop()
+        with Stage() as nested:
+            nested_loop = nested.get(_current_loop)
+        return outer_loop, nested_loop
+
+    outer_loop, nested_loop = outer.get(run_nested_scope)
+    outer.close()
+
+    assert nested_loop is not outer_loop
+    deadline = time.monotonic() + 1
+    while _runtime_snapshot().escape_loop_count and time.monotonic() < deadline:
+        time.sleep(0.001)
+    assert _runtime_snapshot().escape_loop_count == 0
+
+
+def test_stage_adapters_resolve_dynamic_awaitables() -> None:
+    async def resolve(value: int) -> int:
+        await asyncio.sleep(0)
+        return value
+
+    def produces_awaitable(value: int):
+        return resolve(value)
+
+    assert Stage.as_sync(produces_awaitable)(3) == 3
+
+    async def scenario() -> None:
+        assert await Stage.as_async(produces_awaitable)(4) == 4
+
+    asyncio.run(scenario())
+
+
+def test_stage_adapters_preserve_callable_errors() -> None:
+    async def async_failure() -> None:
+        raise ValueError("async adapter failure")
+
+    def sync_failure() -> None:
+        raise LookupError("sync adapter failure")
+
+    with pytest.raises(ValueError, match="async adapter failure"):
+        Stage.as_sync(async_failure)()
+
+    async def scenario() -> None:
+        with pytest.raises(LookupError, match="sync adapter failure"):
+            await Stage.as_async(sync_failure)()
+
+    asyncio.run(scenario())
+
+
+def test_async_context_nested_in_carrier_reuses_physical_loop() -> None:
+    outer = Stage(loop="stage")
+
+    async def run_nested_scope() -> tuple[asyncio.AbstractEventLoop, asyncio.AbstractEventLoop]:
+        outer_loop = asyncio.get_running_loop()
+        async with Stage() as nested:
+            nested_loop = await nested.go(_current_loop).async_get()
+        return outer_loop, nested_loop
+
+    outer_loop, nested_loop = outer.get(run_nested_scope)
+    outer.close()
+
+    assert nested_loop is outer_loop
+
+
+def test_stage_adapters_reject_non_callables_and_stream_functions() -> None:
+    async def async_source():
+        yield 1
+
+    def sync_source():
+        yield 1
+
+    with pytest.raises(TypeError, match="callable"):
+        Stage.as_sync(1)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="callable"):
+        Stage.as_async(1)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="scalar"):
+        Stage.as_sync(async_source)
+    with pytest.raises(TypeError, match="scalar"):
+        Stage.as_async(sync_source)
+
+
+def test_stage_as_async_waits_for_blocking_settlement_before_cancellation() -> None:
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+
+    def blocking() -> None:
+        started.set()
+        release.wait(5)
+        finished.set()
+
+    async def scenario() -> None:
+        task = asyncio.create_task(Stage.as_async(blocking)())
+        assert await asyncio.to_thread(started.wait, 1)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, 1)
+        assert finished.is_set()
+
+    asyncio.run(scenario())
+
+
+def test_context_cleanup_error_does_not_replace_sync_body_error() -> None:
+    def fail_cleanup() -> None:
+        raise RuntimeError("cleanup")
+
+    with pytest.raises(ValueError, match="body") as raised:
+        with Stage() as stage:
+            stage.go(lambda: 1, on_finally=fail_cleanup)
+            raise ValueError("body")
+
+    assert raised.value.__context__ is not None
+    assert isinstance(raised.value.__context__, StageSettlementError)
+    assert [str(error) for error in raised.value.__context__.errors] == ["cleanup"]
+    assert raised.value.__context__.__context__ is None
+
+
+def test_context_cleanup_error_does_not_replace_async_body_error() -> None:
+    async def fail_cleanup() -> None:
+        raise RuntimeError("cleanup")
+
+    async def scenario() -> None:
+        async with Stage() as stage:
+            stage.go(lambda: 1, on_finally=fail_cleanup)
+            raise ValueError("body")
+
+    with pytest.raises(ValueError, match="body") as raised:
+        asyncio.run(scenario())
+
+    assert raised.value.__context__ is not None
+    assert isinstance(raised.value.__context__, StageSettlementError)
+    assert [str(error) for error in raised.value.__context__.errors] == ["cleanup"]
+    assert raised.value.__context__.__context__ is None
+
+
+def test_stage_settings_validate_without_creating_a_carrier() -> None:
+    before = _runtime_snapshot()
+
+    with pytest.raises(KeyError, match="Unknown"):
+        Stage.set_settings("runtime.unknown", 1)
+    with pytest.raises(TypeError, match="positive integer"):
+        Stage.set_settings("runtime.carrier_loop_count", True)
+    with pytest.raises(TypeError, match="positive integer"):
+        Stage.set_settings("runtime.carrier_loop_count", 1.5)
+    with pytest.raises(ValueError, match="greater than zero"):
+        Stage.set_settings("runtime.carrier_loop_count", 0)
+    assert Stage.set_settings("runtime.carrier_loop_count", 1) is Stage
+    assert _runtime_snapshot() == before
+
+
+def test_configured_carrier_pool_balances_active_epochs_and_freezes() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent(
+                """
+                import asyncio
+                import threading
+
+                from agently_stage import Stage, StageLifecycleError
+                from agently_stage._runtime import _runtime_snapshot
+
+                assert Stage.set_settings("runtime.carrier_loop_count", 2) is Stage
+                release = threading.Event()
+                started = [threading.Event(), threading.Event()]
+                loops = []
+
+                async def hold(marker):
+                    loops.append(asyncio.get_running_loop())
+                    marker.set()
+                    await asyncio.to_thread(release.wait, 5)
+
+                async def current_loop():
+                    return asyncio.get_running_loop()
+
+                stages = [Stage(loop="stage"), Stage(loop="stage")]
+                handles = [stage.go(hold, marker) for stage, marker in zip(stages, started)]
+                assert all(marker.wait(1) for marker in started)
+                snapshot = _runtime_snapshot()
+                assert snapshot.carrier_loop_count == 2
+                assert snapshot.active_loop_count == 2
+                assert len(set(loops)) == 2
+                assert stages[0]._generation_lease is not None
+                assert stages[1]._generation_lease is not None
+                assert stages[0]._generation_lease.slot_id != stages[1]._generation_lease.slot_id
+
+                release.set()
+                for handle in handles:
+                    handle.get(timeout=1)
+                    handle.wait_settled(timeout=1)
+                for stage in stages:
+                    stage.close()
+
+                rotating = Stage(loop="stage")
+                first_loop = rotating.get(current_loop)
+                rotating.wait_settled(timeout=1)
+                second_loop = rotating.get(current_loop)
+                rotating.wait_settled(timeout=1)
+                rotating.close()
+                assert first_loop is not second_loop
+
+                Stage.set_settings("runtime.carrier_loop_count", 2)
+                try:
+                    Stage.set_settings("runtime.carrier_loop_count", 3)
+                except StageLifecycleError:
+                    pass
+                else:
+                    raise AssertionError("carrier settings did not freeze")
+                print("carrier-pool-ok")
+                """
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        cwd=".",
+        text=True,
+        timeout=5,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["carrier-pool-ok"]

--- a/tests/test_runtime/test_call_bridge.py
+++ b/tests/test_runtime/test_call_bridge.py
@@ -263,6 +263,62 @@ def test_sync_bridge_reentry_on_its_carrier_fails_before_inner_submission() -> N
     bridge.close()
 
 
+def test_sync_bridge_rejects_same_physical_carrier_from_another_stage() -> None:
+    bridge = StageCallBridge()
+    outer_stage = Stage(loop="stage")
+    inner_calls = 0
+
+    async def inner() -> str:
+        nonlocal inner_calls
+        inner_calls += 1
+        return "inner"
+
+    async def outer() -> None:
+        with pytest.raises(StageLifecycleError, match="carrier"):
+            bridge.as_sync(inner)()
+
+    outer_stage.get(outer)
+    outer_stage.close()
+    assert inner_calls == 0
+    bridge.close()
+
+
+def test_sync_bridge_allows_worker_round_trip_back_to_carrier() -> None:
+    bridge = StageCallBridge()
+
+    async def async_leaf() -> tuple[str, asyncio.AbstractEventLoop]:
+        return "ok", asyncio.get_running_loop()
+
+    def sync_middle() -> tuple[str, asyncio.AbstractEventLoop]:
+        return bridge.as_sync(async_leaf)()
+
+    async def async_root() -> tuple[str, bool]:
+        outer_loop = asyncio.get_running_loop()
+        value, leaf_loop = await bridge.as_async(sync_middle)()
+        return value, leaf_loop is outer_loop
+
+    assert bridge.as_sync(async_root)() == ("ok", True)
+    bridge.close()
+
+
+def test_sync_bridge_worker_round_trip_stress_does_not_deadlock() -> None:
+    bridge = StageCallBridge()
+
+    async def async_leaf(value: int) -> int:
+        await asyncio.sleep(0)
+        return value
+
+    def sync_middle(value: int) -> int:
+        return bridge.as_sync(async_leaf)(value)
+
+    async def async_root() -> list[int]:
+        bridged = bridge.as_async(sync_middle)
+        return await asyncio.gather(*(bridged(value) for value in range(64)))
+
+    assert bridge.as_sync(async_root)() == list(range(64))
+    bridge.close()
+
+
 def test_iter_sync_closes_async_source_on_early_consumer_close() -> None:
     finalized = threading.Event()
 

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "agently-stage"
-version = "0.3.4"
+version = "0.3.6"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- separate logical Stage lineage from physical carrier-loop deadlock checks
- make sync and async Stage scopes automatically choose a safe environment
- add scoped Stage.as_sync / Stage.as_async adapters
- add the finite, lazy runtime.carrier_loop_count carrier pool setting
- preserve primary body exceptions during settlement cleanup

## Issue context

Addresses Agently-Stage #24 and #25 and the cross-repository path in AgentEra/Agently#347. This keeps provider-owned synchronous wrappers valid even when TriggerFlow already uses Stage internally.

## Validation

- Python 3.10 full suite: 215 passed, 1 skipped
- repository pre-commit hooks: passed
- pyright: 0 errors
- uv lock --check: passed
- uv build: passed
- installed-wheel smoke against the unchanged reported teaching script: passed with deterministic offline provider substitutes

Release target: agently-stage 0.3.6.