### PR TITLE
fix: route transitive synchronous Stage waits

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ Creating a `Stage` does not create a thread, loop, or permanent loop binding.
 The first admitted root in each active epoch selects its backend lazily:
 
 - inside an async service, `Stage()` uses that service's current running loop;
-- without a running loop, `Stage()` uses the process-wide Stage carrier;
+- in a Stage-owned worker without a running loop, `Stage()` reuses a safe
+  inherited caller loop or carrier;
+- otherwise, without a running loop, `Stage()` uses the process-wide Stage
+  carrier;
 - after complete settlement, a reusable automatic Stage releases the binding
   and selects again when later work arrives.
 
@@ -169,6 +172,12 @@ replace the loop's task factory: settlement covers work created through
 tasks explicitly attached with `Stage.adopt()`. An unrelated raw
 `asyncio.create_task()` remains owned by the caller.
 
+`Stage.create_task()` also installs the Stage's logical lineage in the new
+task's context. If that task later awaits a blocking worker, a nested automatic
+sync scope can safely return to the caller loop that is asynchronously waiting
+for the worker. This propagates ownership information without treating the
+worker as if it physically executed that loop.
+
 ### Callback observers
 
 Callbacks are ordered observers, not Promise-style result transformations.
@@ -229,10 +238,13 @@ releases an automatic binding; the next root selects again.
 `with Stage()` and `async with Stage()` are lifecycle conveniences. A sync
 context selects a physically safe carrier; an async context prefers its current
 running loop. Context exit seals the scope and waits for Stage-owned work. An
-empty context creates no loop. Nested automatic sync scopes reuse an inherited
-carrier when the caller is a worker; if the caller physically runs the only
-eligible carrier loop, Stage uses a temporary escape carrier rather than
-deadlocking. The logical scopes and settlement inventories remain independent.
+empty context creates no loop. Nested automatic sync scopes reuse a safe
+inherited caller loop or carrier when the caller is a worker. If the caller
+physically runs the selected carrier, Stage uses another configured carrier or
+a temporary escape carrier. The selector also excludes every upstream carrier
+generation that is synchronously waiting for the current scope, preventing a
+transitive `carrier A -> escape B -> carrier A` wait cycle. The logical scopes
+and settlement inventories remain independent.
 
 `Stage.close()` and `Stage.async_close()` are scope barriers for explicit
 application lifecycles. They are not required to make an ordinary script exit:
@@ -468,12 +480,16 @@ Python cannot preempt that thread. Use `as_async(function, managed=True)` when
 the caller owns the task lifetime and cancellation acknowledgement must wait
 until the blocking call actually returns or raises.
 
-`as_sync()` resolves awaitables through the finite Stage carrier and fails fast
-if a synchronous wait would re-enter that same carrier. It may be called while
-another loop is running in the caller thread for compatibility, but it blocks
-that thread and the awaitable must not own objects bound to the caller loop;
-ordinary async code should await instead. By default it returns the body
-outcome without adding a settlement barrier; use
+`as_sync()` resolves awaitables through an automatically routed Stage
+environment. A Stage-owned worker can return to the caller loop or carrier that
+is asynchronously waiting for it. A call made on its selected carrier uses an
+alternate or temporary escape carrier, and transitive synchronous-wait
+ancestors remain ineligible. It may be called while another loop is running in
+the caller thread for compatibility, but it blocks that thread. Work bound to
+that blocked owner loop cannot be moved safely and fails with guidance to use
+`async with Stage()` / `await`; ordinary async code should await directly. By
+default the bridge returns the body outcome without adding a settlement
+barrier; use
 `as_sync(function, managed=True)` when the boundary owns descendant work and
 must wait for it. A primary body error is never replaced by a duplicate
 settlement error. `submit()` returns a loop-neutral managed `StageHandle`.

--- a/agently_stage/Stage.py
+++ b/agently_stage/Stage.py
@@ -226,6 +226,7 @@ class Stage:
             executor if executor is not None else self._private_executor or _RUNTIME_CARRIER.blocking_executor
         )
         self._generation_lease: _Generation | None = None
+        self._blocked_generation_ids: frozenset[int] = frozenset()
         self._active_backend: _BackendKind | None = None
         self._active_loop: AbstractEventLoop | None = None
         self._context_mode: _ContextMode | None = None
@@ -278,6 +279,27 @@ class Stage:
     def _callback_registration_allowed(self) -> bool:
         return not self._sealed or _active_stage.get() is self
 
+    @staticmethod
+    def _inherited_caller_loop_for_sync() -> AbstractEventLoop | None:
+        """Return a caller loop that is asynchronously waiting for this worker."""
+
+        outer = _active_stage.get()
+        if outer is None:
+            return None
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+        else:
+            return None
+        with outer._scope_lock:
+            if outer._active_backend != "caller":
+                return None
+            loop = outer._active_loop
+        if loop is None or loop.is_closed() or not loop.is_running():
+            return None
+        return loop
+
     def _resolve_backend_locked(self) -> tuple[_BackendKind, AbstractEventLoop | None]:
         if self._active_backend is not None:
             return self._active_backend, self._active_loop
@@ -291,15 +313,24 @@ class Stage:
             backend = "stage"
             loop = None
         else:
+            inherited_caller_loop = self._inherited_caller_loop_for_sync()
             if self._context_mode == "sync":
-                backend = "stage"
-                loop = None
+                if inherited_caller_loop is None:
+                    backend = "stage"
+                    loop = None
+                else:
+                    backend = "caller"
+                    loop = inherited_caller_loop
             else:
                 try:
                     loop = asyncio.get_running_loop()
                 except RuntimeError:
-                    backend = "stage"
-                    loop = None
+                    if inherited_caller_loop is None:
+                        backend = "stage"
+                        loop = None
+                    else:
+                        backend = "caller"
+                        loop = inherited_caller_loop
                 else:
                     backend = "caller"
 
@@ -307,6 +338,12 @@ class Stage:
             self._generation_lease = _RUNTIME_CARRIER.acquire_lease(
                 avoid_current_loop=self._context_mode == "sync",
             )
+            self._blocked_generation_ids = _RUNTIME_CARRIER.blocked_generation_ids_for_submission(
+                self._generation_lease,
+                synchronous_scope=self._context_mode == "sync",
+            )
+        else:
+            self._blocked_generation_ids = frozenset()
         self._active_backend = backend
         self._active_loop = loop
         return backend, loop
@@ -498,10 +535,15 @@ class Stage:
                     raise StageLifecycleError("Stage callback owner loop is unavailable")
                 self._active_backend = "caller"
                 self._active_loop = handle_loop
+                self._blocked_generation_ids = frozenset()
             else:
                 self._active_backend = "stage"
                 self._active_loop = None
                 self._generation_lease = _RUNTIME_CARRIER.acquire_lease()
+                self._blocked_generation_ids = _RUNTIME_CARRIER.blocked_generation_ids_for_submission(
+                    self._generation_lease,
+                    synchronous_scope=False,
+                )
         elif self._active_backend != handle._backend_kind or (
             self._active_backend == "caller" and self._active_loop is not handle_loop
         ):
@@ -524,6 +566,7 @@ class Stage:
             preferred=self._generation_lease,
             owner=False,
             phase=_WorkPhase.SETTLEMENT,
+            blocked_generation_ids=self._blocked_generation_ids,
         )
 
     @overload
@@ -665,6 +708,7 @@ class Stage:
                     handle,
                     body,
                     preferred=self._generation_lease,
+                    blocked_generation_ids=self._blocked_generation_ids,
                 )
             except BaseException:
                 self._finish_admission(admission)
@@ -715,6 +759,11 @@ class Stage:
                     lease = self._release_backend_if_quiescent_locked()
                     if lease is not None:
                         _RUNTIME_CARRIER.release_lease(lease)
+                    if backend == "caller" and selected_loop is not None:
+                        raise StageLifecycleError(
+                            "Stage.create_task cannot move caller-loop-owned work to another event loop; "
+                            "use 'async with Stage()' and await the async operation on its owner loop"
+                        )
                     raise StageLifecycleError(
                         "Stage.create_task requires the current running caller event loop backend"
                     )
@@ -723,6 +772,7 @@ class Stage:
             raise
 
         context = contextvars.copy_context()
+        context.run(_active_stage.set, self)
         try:
             if name is None:
                 task = context.run(loop.create_task, coroutine)
@@ -1029,6 +1079,7 @@ class Stage:
             timer.cancel()
         lease = self._generation_lease
         self._generation_lease = None
+        self._blocked_generation_ids = frozenset()
         self._active_backend = None
         self._active_loop = None
         self._cancelling = False

--- a/agently_stage/StageCallBridge.py
+++ b/agently_stage/StageCallBridge.py
@@ -6,6 +6,7 @@ import contextvars
 import functools
 import inspect
 import threading
+import weakref
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
 
 from ._runtime import _RUNTIME_CARRIER
@@ -50,6 +51,7 @@ class StageCallBridge:
         self._submit_stage = stage if stage is not None else Stage(executor=executor)
         self._owns_submit_stage = stage is None
         self._carrier_stage = Stage(loop="stage", executor=executor)
+        self._routed_stages: weakref.WeakSet[Stage] = weakref.WeakSet()
 
     def _ensure_open(self) -> None:
         with self._lock:
@@ -63,13 +65,8 @@ class StageCallBridge:
         return callable(function) and inspect.iscoroutinefunction(function.__call__)
 
     def _resolve_awaitable_sync(self, awaitable: Awaitable[T], *, managed: bool) -> T:
-        if _RUNTIME_CARRIER.would_sync_wait_block_current_carrier(self._carrier_stage):
-            close = getattr(awaitable, "close", None)
-            if close is not None:
-                close()
-            raise StageLifecycleError(
-                "A synchronous StageCallBridge call cannot re-enter and block its own carrier execution"
-            )
+        if self._requires_routed_sync_scope():
+            return self._resolve_awaitable_in_routed_scope(awaitable, managed=managed)
         handle = self._carrier_stage.go(awaitable)
         if not managed:
             return handle.result()
@@ -84,6 +81,57 @@ class StageCallBridge:
         handle.wait_settled()
         return result
 
+    def _requires_routed_sync_scope(self) -> bool:
+        return (
+            Stage._inherited_caller_loop_for_sync() is not None
+            or _RUNTIME_CARRIER.would_sync_wait_block_current_carrier(self._carrier_stage)
+        )
+
+    def _resolve_awaitable_in_routed_scope(self, awaitable: Awaitable[T], *, managed: bool) -> T:
+        with self._lock:
+            if self._closing:
+                close = getattr(awaitable, "close", None)
+                if close is not None:
+                    close()
+                raise StageLifecycleError("StageCallBridge is closed")
+            stage = Stage(executor=self._executor)
+            self._routed_stages.add(stage)
+
+        entered = False
+        try:
+            stage.__enter__()
+            entered = True
+            try:
+                handle = stage.go(awaitable)
+            except BaseException:
+                close = getattr(awaitable, "close", None)
+                if close is not None:
+                    close()
+                raise
+            try:
+                result = handle.result()
+            except BaseException:
+                stage.seal()
+                if managed:
+                    try:
+                        stage.close()
+                    except BaseException:
+                        pass
+                raise
+            stage.seal()
+            if managed:
+                stage.close()
+            return result
+        finally:
+            if not entered:
+                try:
+                    stage.close()
+                except BaseException:
+                    pass
+            if managed or stage.snapshot().active_count == 0:
+                with self._lock:
+                    self._routed_stages.discard(stage)
+
     def as_sync(
         self,
         function: Callable[P, T | Awaitable[T]],
@@ -92,16 +140,11 @@ class StageCallBridge:
     ) -> Callable[P, T]:
         if not callable(function):
             raise TypeError(f"Expected a callable, got {type(function)}")
-        async_callable = self._is_async_callable(function)
         should_manage = self._managed_by_default if managed is None else managed
 
         @functools.wraps(function)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             self._ensure_open()
-            if async_callable and _RUNTIME_CARRIER.would_sync_wait_block_current_carrier(self._carrier_stage):
-                raise StageLifecycleError(
-                    "A synchronous StageCallBridge call cannot re-enter and block its own carrier execution"
-                )
             result = function(*args, **kwargs)
             if inspect.isawaitable(result):
                 return self._resolve_awaitable_sync(
@@ -211,11 +254,15 @@ class StageCallBridge:
                 if self._closed:
                     return
                 self._closing = True
+                routed_stages = tuple(self._routed_stages)
+            for stage in routed_stages:
+                stage.close(timeout=timeout)
             self._carrier_stage.close(timeout=timeout)
             if self._owns_submit_stage:
                 self._submit_stage.close(timeout=timeout)
             with self._lock:
                 self._closed = True
+                self._routed_stages.clear()
 
     async def async_close(self, timeout: float | None = None) -> None:
         await asyncio.to_thread(self.close, timeout)

--- a/agently_stage/_runtime.py
+++ b/agently_stage/_runtime.py
@@ -52,6 +52,7 @@ class _Submission:
     owner: bool
     context: contextvars.Context
     phase: _WorkPhase
+    blocked_generation_ids: frozenset[int]
 
 
 @dataclass
@@ -70,6 +71,7 @@ class _ExecutionContext:
     generation: _Generation
     handle: StageHandle[Any]
     phase: _WorkPhase
+    blocked_generation_ids: frozenset[int] = frozenset()
 
 
 _active_execution: contextvars.ContextVar[_ExecutionContext | None] = contextvars.ContextVar(
@@ -107,6 +109,7 @@ class _CarrierSlot:
         preferred: _Generation | None = None,
         owner: bool = True,
         phase: _WorkPhase = _WorkPhase.BODY,
+        blocked_generation_ids: frozenset[int] = frozenset(),
     ) -> int:
         submission_context = contextvars.copy_context()
         handle._retain_work()
@@ -120,6 +123,7 @@ class _CarrierSlot:
                     owner=owner,
                     context=submission_context,
                     phase=phase,
+                    blocked_generation_ids=blocked_generation_ids,
                 )
                 loop = generation.loop
                 if loop is None:
@@ -160,6 +164,17 @@ class _CarrierSlot:
 
     def owns_generation(self, generation: _Generation) -> bool:
         return generation.slot_id == self.slot_id
+
+    def owns_any_generation_id(self, generation_ids: frozenset[int]) -> bool:
+        if not generation_ids:
+            return False
+        with self._admission_lock:
+            return any(
+                generation is not None
+                and generation.state is not _GenerationState.CLOSED
+                and generation.generation_id in generation_ids
+                for generation in (self._current, self._next)
+            )
 
     def shutdown(self) -> None:
         self._control_executor.shutdown(wait=False)
@@ -303,6 +318,7 @@ class _CarrierSlot:
                 generation=generation,
                 handle=submission.handle,
                 phase=submission.phase,
+                blocked_generation_ids=submission.blocked_generation_ids,
             )
         )
         try:
@@ -410,20 +426,28 @@ class _RuntimeCarrier:
     def would_sync_wait_block_current_carrier(self, stage: Stage) -> bool:
         """Return whether ``stage`` would target the carrier loop now executing."""
 
+        context = _active_execution.get()
+        with stage._scope_lock:
+            generation = stage._generation_lease
+            active_backend = stage._active_backend
+        if (
+            active_backend == "stage"
+            and generation is not None
+            and context is not None
+            and generation.generation_id in context.blocked_generation_ids
+        ):
+            return True
+
         try:
             running_loop = asyncio.get_running_loop()
         except RuntimeError:
             return False
-        with stage._scope_lock:
-            generation = stage._generation_lease
-            active_backend = stage._active_backend
         if active_backend == "stage" and generation is not None:
             return generation.loop is running_loop
 
         # An unbound carrier Stage inherits the physically active generation on
         # first lease. Context propagation into a blocking worker is harmless:
         # such a worker has no running loop and returned above.
-        context = _active_execution.get()
         return active_backend is None and context is not None and context.generation.loop is running_loop
 
     def submit(
@@ -434,9 +458,13 @@ class _RuntimeCarrier:
         preferred: _Generation | None = None,
         owner: bool = True,
         phase: _WorkPhase = _WorkPhase.BODY,
+        blocked_generation_ids: frozenset[int] = frozenset(),
     ) -> int:
         if preferred is None:
-            slot = self._select_slot(avoid_current_loop=False)
+            slot = self._select_slot(
+                avoid_current_loop=False,
+                blocked_generation_ids=blocked_generation_ids,
+            )
         else:
             slot = self._slot_for_generation(preferred)
         return slot.submit(
@@ -445,20 +473,47 @@ class _RuntimeCarrier:
             preferred=preferred,
             owner=owner,
             phase=phase,
+            blocked_generation_ids=blocked_generation_ids,
         )
 
     def acquire_lease(self, *, avoid_current_loop: bool = False) -> _Generation:
         self._freeze_settings()
         inherited = _active_execution.get()
-        if inherited is not None and not self._generation_is_current_loop(
-            inherited.generation,
-            only_when=avoid_current_loop,
+        blocked_generation_ids: frozenset[int] = frozenset() if inherited is None else inherited.blocked_generation_ids
+        if (
+            inherited is not None
+            and inherited.generation.generation_id not in blocked_generation_ids
+            and not self._generation_is_current_loop(
+                inherited.generation,
+                only_when=avoid_current_loop,
+            )
         ):
             try:
                 return self._slot_for_generation(inherited.generation).acquire_lease(inherited.generation)
             except StageLifecycleError:
                 pass
-        return self._select_slot(avoid_current_loop=avoid_current_loop).acquire_lease()
+        return self._select_slot(
+            avoid_current_loop=avoid_current_loop,
+            blocked_generation_ids=blocked_generation_ids,
+        ).acquire_lease()
+
+    def blocked_generation_ids_for_submission(
+        self,
+        generation: _Generation,
+        *,
+        synchronous_scope: bool,
+    ) -> frozenset[int]:
+        """Return carrier ancestors that must not receive this scope's descendants."""
+
+        context = _active_execution.get()
+        if context is None:
+            return frozenset()
+        blocked_generation_ids = context.blocked_generation_ids
+        if synchronous_scope and generation is not context.generation:
+            blocked_generation_ids = blocked_generation_ids | {
+                context.generation.generation_id,
+            }
+        return blocked_generation_ids
 
     def release_lease(self, generation: _Generation) -> None:
         self._slot_for_generation(generation).release_lease(generation)
@@ -474,6 +529,7 @@ class _RuntimeCarrier:
                 generation=context.generation,
                 handle=context.handle,
                 phase=_WorkPhase.SETTLEMENT,
+                blocked_generation_ids=context.blocked_generation_ids,
             )
         )
         try:
@@ -553,7 +609,12 @@ class _RuntimeCarrier:
             return False
         return generation.loop is running_loop
 
-    def _select_slot(self, *, avoid_current_loop: bool) -> _CarrierSlot:
+    def _select_slot(
+        self,
+        *,
+        avoid_current_loop: bool,
+        blocked_generation_ids: frozenset[int] = frozenset(),
+    ) -> _CarrierSlot:
         self._freeze_settings()
         try:
             running_loop = asyncio.get_running_loop()
@@ -564,6 +625,8 @@ class _RuntimeCarrier:
             cursor = self._selection_cursor
         candidates: list[tuple[int, int, _CarrierSlot]] = []
         for index, slot in enumerate(slots):
+            if slot.owns_any_generation_id(blocked_generation_ids):
+                continue
             if avoid_current_loop and running_loop is not None and slot.owns_loop(running_loop):
                 continue
             _, _, _, pressure = slot.snapshot()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agently-stage"
-version = "0.3.6"
+version = "0.3.7"
 description = "Agently Stage - Efficient Convenient Asynchronous and Multithreaded Programming"
 authors = [
     { name = "Agently Team", email = "developer@agently.tech" },

--- a/tests/test_runtime/test_automatic_environment.py
+++ b/tests/test_runtime/test_automatic_environment.py
@@ -146,6 +146,82 @@ def test_sync_context_on_carrier_uses_an_escape_loop() -> None:
     assert _runtime_snapshot().escape_loop_count == 0
 
 
+def test_sync_context_avoids_every_transitively_blocked_carrier() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent(
+                """
+                import asyncio
+                import time
+                from concurrent.futures import ThreadPoolExecutor
+
+                from agently_stage import Stage
+                from agently_stage._runtime import _runtime_snapshot
+
+                loops = []
+
+                async def sdk():
+                    loops.append(asyncio.get_running_loop())
+                    return "ok"
+
+                async def action():
+                    loops.append(asyncio.get_running_loop())
+                    with Stage() as inner:
+                        return inner.get(sdk)
+
+                def manager():
+                    with Stage() as outer:
+                        return outer.get(action)
+
+                async def chunk():
+                    loops.append(asyncio.get_running_loop())
+                    return manager()
+
+                assert Stage.as_sync(chunk)() == "ok"
+                assert len(set(loops)) == 3
+
+                with ThreadPoolExecutor(max_workers=8) as executor:
+                    results = list(executor.map(lambda _: Stage.as_sync(chunk)(), range(24)))
+                assert results == ["ok"] * 24
+
+                deadline = time.monotonic() + 1
+                while _runtime_snapshot().escape_loop_count and time.monotonic() < deadline:
+                    time.sleep(0.001)
+                assert _runtime_snapshot().escape_loop_count == 0
+                print("transitive-carrier-ok")
+                """
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        cwd=".",
+        text=True,
+        timeout=3,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["transitive-carrier-ok"]
+
+
+def test_sync_context_in_worker_reuses_inherited_caller_loop() -> None:
+    async def scenario() -> tuple[asyncio.AbstractEventLoop, asyncio.AbstractEventLoop]:
+        caller_loop = asyncio.get_running_loop()
+
+        def sync_middle() -> asyncio.AbstractEventLoop:
+            with Stage() as nested:
+                return nested.get(_current_loop)
+
+        async with Stage() as outer:
+            observed_loop = await outer.go(sync_middle).async_get()
+        return caller_loop, observed_loop
+
+    caller_loop, observed_loop = asyncio.run(scenario())
+
+    assert observed_loop is caller_loop
+
+
 def test_stage_adapters_resolve_dynamic_awaitables() -> None:
     async def resolve(value: int) -> int:
         await asyncio.sleep(0)

--- a/tests/test_runtime/test_call_bridge.py
+++ b/tests/test_runtime/test_call_bridge.py
@@ -243,43 +243,85 @@ def test_done_callback_uses_registration_context() -> None:
     bridge.close()
 
 
-def test_sync_bridge_reentry_on_its_carrier_fails_before_inner_submission() -> None:
+def test_sync_bridge_reentry_on_its_carrier_uses_an_escape_scope() -> None:
     bridge = StageCallBridge()
-    inner_calls = 0
 
-    async def inner() -> str:
-        nonlocal inner_calls
-        inner_calls += 1
-        return "inner"
+    async def inner() -> tuple[str, asyncio.AbstractEventLoop]:
+        return "inner", asyncio.get_running_loop()
 
     sync_inner = bridge.as_sync(inner)
 
-    async def outer() -> None:
-        with pytest.raises(StageLifecycleError, match="carrier"):
-            sync_inner()
+    async def outer() -> tuple[str, bool]:
+        outer_loop = asyncio.get_running_loop()
+        value, inner_loop = sync_inner()
+        return value, inner_loop is not outer_loop
 
-    bridge.as_sync(outer)()
-    assert inner_calls == 0
+    assert bridge.as_sync(outer)() == ("inner", True)
     bridge.close()
 
 
-def test_sync_bridge_rejects_same_physical_carrier_from_another_stage() -> None:
+def test_sync_bridge_escape_keeps_light_settlement_semantics() -> None:
     bridge = StageCallBridge()
-    outer_stage = Stage(loop="stage")
-    inner_calls = 0
+    child_started = threading.Event()
+    child_release = threading.Event()
+    child_finished = threading.Event()
 
     async def inner() -> str:
-        nonlocal inner_calls
-        inner_calls += 1
+        async def child() -> None:
+            child_started.set()
+            await asyncio.to_thread(child_release.wait, 5)
+            child_finished.set()
+
+        asyncio.create_task(child())
+        await asyncio.sleep(0)
         return "inner"
 
-    async def outer() -> None:
-        with pytest.raises(StageLifecycleError, match="carrier"):
-            bridge.as_sync(inner)()
+    async def outer() -> str:
+        return bridge.as_sync(inner)()
 
-    outer_stage.get(outer)
+    assert bridge.as_sync(outer)() == "inner"
+    assert child_started.wait(1)
+    assert not child_finished.is_set()
+
+    child_release.set()
+    bridge.close()
+    assert child_finished.is_set()
+
+
+def test_sync_bridge_escape_honors_managed_settlement() -> None:
+    bridge = StageCallBridge()
+    child_finished = threading.Event()
+
+    async def inner() -> str:
+        async def child() -> None:
+            await asyncio.sleep(0.01)
+            child_finished.set()
+
+        asyncio.create_task(child())
+        return "inner"
+
+    async def outer() -> str:
+        return bridge.as_sync(inner, managed=True)()
+
+    assert bridge.as_sync(outer)() == "inner"
+    assert child_finished.is_set()
+    bridge.close()
+
+
+def test_sync_bridge_uses_escape_scope_on_another_stage_carrier() -> None:
+    bridge = StageCallBridge()
+    outer_stage = Stage(loop="stage")
+
+    async def inner() -> tuple[str, asyncio.AbstractEventLoop]:
+        return "inner", asyncio.get_running_loop()
+
+    async def outer() -> tuple[str, bool]:
+        outer_loop = asyncio.get_running_loop()
+        value, inner_loop = bridge.as_sync(inner)()
+        return value, inner_loop is not outer_loop
+
+    assert outer_stage.get(outer) == ("inner", True)
     outer_stage.close()
-    assert inner_calls == 0
     bridge.close()
 
 
@@ -298,6 +340,61 @@ def test_sync_bridge_allows_worker_round_trip_back_to_carrier() -> None:
         return value, leaf_loop is outer_loop
 
     assert bridge.as_sync(async_root)() == ("ok", True)
+    bridge.close()
+
+
+def test_sync_bridge_worker_round_trip_reuses_caller_loop() -> None:
+    bridge = StageCallBridge()
+
+    async def scenario() -> tuple[str, bool]:
+        caller_loop = asyncio.get_running_loop()
+
+        async def async_state_update() -> tuple[str, asyncio.AbstractEventLoop]:
+            task = owner.create_task(asyncio.sleep(0), origin="state-listener")
+            await task
+            return "updated", asyncio.get_running_loop()
+
+        def sync_chunk() -> tuple[str, asyncio.AbstractEventLoop]:
+            return bridge.as_sync(async_state_update)()
+
+        async def run_sync_chunk() -> tuple[str, asyncio.AbstractEventLoop]:
+            return await bridge.as_async(sync_chunk, managed=True)()
+
+        async with Stage() as owner:
+            task = owner.create_task(run_sync_chunk(), origin="sync-chunk")
+            value, observed_loop = await task
+        return value, observed_loop is caller_loop
+
+    assert asyncio.run(scenario()) == ("updated", True)
+    bridge.close()
+
+
+def test_sync_bridge_fails_fast_for_work_bound_to_blocked_owner_loop() -> None:
+    bridge = StageCallBridge()
+
+    async def scenario() -> None:
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def hold_owner_loop() -> None:
+            started.set()
+            await release.wait()
+
+        async def loop_bound_update() -> None:
+            task = owner.create_task(asyncio.sleep(0), origin="state-listener")
+            await task
+
+        async with Stage() as owner:
+            owner_task = owner.create_task(hold_owner_loop(), origin="owner-loop")
+            await started.wait()
+            try:
+                with pytest.raises(StageLifecycleError, match=r"await.+owner loop"):
+                    bridge.as_sync(loop_bound_update)()
+            finally:
+                release.set()
+                await owner_task
+
+    asyncio.run(scenario())
     bridge.close()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "agently-stage"
-version = "0.3.6"
+version = "0.3.7"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- carry synchronously waiting carrier-generation ancestry through Stage execution context and exclude every live ancestor from nested selection
- route StageCallBridge synchronous re-entry through an automatic sync scope while preserving the light default, managed settlement, and bridge close ownership
- propagate Stage logical lineage into tasks created by Stage.create_task so safe worker-to-caller-loop round trips stay on the owner loop
- keep real owner-loop affinity conflicts as fast StageLifecycleError failures with async/await guidance
- bump the corrective release candidate to 0.3.7

## Script-derived regression evidence

The deterministic TriggerFlow / ActionManager / nested Stage matrix uses public Agently 4.1.4.6 in both comparisons:

- public Stage 0.3.6: 150 cases, 106 pass, 36 error, 8 timeout
- this 0.3.7 candidate: 150 cases, 144 pass, 6 expected owner-loop affinity errors, 0 timeout
- all expected listener paths executed and all passing cases reclaimed escape carriers

The eight former timeouts were the verified wait graph carrier A -> escape B -> carrier A.

## Validation

- Python 3.10 full pytest: 221 passed, 1 skipped
- Ruff lint and format: passed
- pyright: 0 errors
- pre-commit: passed
- uv lock --check: passed
- wheel and sdist build: passed
- clean Python 3.10 wheel smoke: passed
